### PR TITLE
Fix error of referencing settings prematurely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## Version 0.0.12 (2022-11-15)
+
+- bug fixes.
+
 ## Version 0.0.11 (2022-10-28)
 
 - bug fixes. remove django-environ and validators from INSTALLED_APPS
@@ -10,7 +14,7 @@
 - validate event.setter against MemberpressEvents.all_events()
 - validate event_type.setter against MemberpressEventTypes.all_event_types()
 - add more event tests
-- createe .env-sample for local and production
+- create .env-sample for local and production
 
 ## Version 0.0.5 (2022-10-17)
 

--- a/memberpress_client/constants.py
+++ b/memberpress_client/constants.py
@@ -157,8 +157,13 @@ class MemberPressAPI_Endpoints:
     # -------------------------------------------------------------------------
     # api end points originating from https://stepwisemath.ai/wp-json/mp/v1/
     # -------------------------------------------------------------------------
-    MEMBERPRESS_API_BASE = settings.MEMBERPRESS_API_BASE_URL + "wp-json/mp/v1/"
-    MEMBERPRESS_API_ME_PATH = MEMBERPRESS_API_BASE + "me/"
+    @property
+    def MEMBERPRESS_API_BASE(self):
+        return f"{settings.MEMBERPRESS_API_BASE_URL}wp-json/mp/v1/"
+
+    @property
+    def MEMBERPRESS_API_ME_PATH(self):
+        return f"{settings.MEMBERPRESS_API_BASE}me/"
 
     # -------------------------------------------------------------------------
     # curl "https://set-me-please.com/wp-json/mp/v1/members?search=mcdaniel" -H "MEMBERPRESS-API-KEY: set-me-please"

--- a/memberpress_client/constants.py
+++ b/memberpress_client/constants.py
@@ -7,7 +7,7 @@ memberpress REST API Client plugin for Django - plugin constants
 
 # django stuff
 from django.conf import settings
-from django.utils.decorators import classproperty
+from django.utils.functional import classproperty
 
 
 class MemberpressTransactionTypes:

--- a/memberpress_client/constants.py
+++ b/memberpress_client/constants.py
@@ -7,6 +7,7 @@ memberpress REST API Client plugin for Django - plugin constants
 
 # django stuff
 from django.conf import settings
+from django.utils.decorators import classproperty
 
 
 class MemberpressTransactionTypes:
@@ -157,13 +158,14 @@ class MemberPressAPI_Endpoints:
     # -------------------------------------------------------------------------
     # api end points originating from https://stepwisemath.ai/wp-json/mp/v1/
     # -------------------------------------------------------------------------
-    @property
-    def MEMBERPRESS_API_BASE(self):
+
+    @classproperty
+    def MEMBERPRESS_API_BASE(cls):
         return f"{settings.MEMBERPRESS_API_BASE_URL}wp-json/mp/v1/"
 
-    @property
-    def MEMBERPRESS_API_ME_PATH(self):
-        return f"{settings.MEMBERPRESS_API_BASE}me/"
+    @classproperty
+    def MEMBERPRESS_API_ME_PATH(cls):
+        return f"{cls.MEMBERPRESS_API_BASE}me/"
 
     # -------------------------------------------------------------------------
     # curl "https://set-me-please.com/wp-json/mp/v1/members?search=mcdaniel" -H "MEMBERPRESS-API-KEY: set-me-please"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 #------------------------------------------------------------------------------
 [project]
 name = "django-memberpress-client"
-version = "0.0.11"
+version = "0.0.12"
 authors = [
   { name="Lawrence McDaniel", email="lpm0073@gmail.com" }
 ]


### PR DESCRIPTION
When settings were referenced in static property definitions, they were getting evaluated during server startup before the particular settings values were set. This was causing an error saying that the `MEMBERPRESS_API_BASE_URL` attribute did not exist. Converting them into classproperties, allows time for the settings to get fully initialized before the values are calculated in a lazy fashion during runtime.